### PR TITLE
visreader:fix bug in shared memory allocation

### DIFF
--- a/visreader/python/visreader/reader_builder/imagenet/imagenet.py
+++ b/visreader/python/visreader/reader_builder/imagenet/imagenet.py
@@ -96,7 +96,6 @@ def train(settings=None):
         worker_args['use_sharedmem'] = False
     elif worker_args['worker_mode'] == 'python_process':
         worker_args['use_process'] = True
-        worker_args['use_sharedmem'] = True
     else:
         raise ValueError('not recognized mode[%s] for worker_args' %
                          (worker_args['worker_mode']))
@@ -146,6 +145,18 @@ def val(settings=None):
         ]
         worker_args['use_process'] = False
         worker_args['use_sharedmem'] = False
+
+    if worker_args['worker_mode'] == 'native_thread':
+        worker_args['use_process'] = False
+        worker_args['use_sharedmem'] = False
+    elif worker_args['worker_mode'] == 'python_thread':
+        worker_args['use_process'] = False
+        worker_args['use_sharedmem'] = False
+    elif worker_args['worker_mode'] == 'python_process':
+        worker_args['use_process'] = True
+    else:
+        raise ValueError('not recognized mode[%s] for worker_args' %
+                         (worker_args['worker_mode']))
 
     pl.map_ops(img_ops, **worker_args)
     return pl

--- a/visreader/python/visreader/shared_queue/__init__.py
+++ b/visreader/python/visreader/shared_queue/__init__.py
@@ -2,4 +2,5 @@ __all__ = ['SharedBuffer', 'SharedMemoryMgr', 'SharedQueue']
 
 from .sharedmemory import SharedBuffer
 from .sharedmemory import SharedMemoryMgr
+from .sharedmemory import SharedMemoryError
 from .queue import SharedQueue

--- a/visreader/python/visreader/shared_queue/queue.py
+++ b/visreader/python/visreader/shared_queue/queue.py
@@ -74,10 +74,6 @@ class SharedQueue(Queue):
             raise e
 
         data = buff.get()
-        if data is None:
-            raise SharedQueueError('failed to extract data from shared buffer[%s]'\
-                % (str(buff)))
-
         buff.free()
         return cPickle.loads(data)
 

--- a/visreader/python/visreader/test/test_imagenet.py
+++ b/visreader/python/visreader/test/test_imagenet.py
@@ -130,7 +130,7 @@ def parse_args():
         help='whether to use lua operators, default to False')
     parser.add_argument(
         '-use_sharedmem',
-        default=false,
+        default='false',
         type=str,
         help='whether to use shared memory as IPC when using process as workers, default to false'
     )


### PR DESCRIPTION
updates：
1, fix bug that SharedMemoryMgr cann't malloc new pages when there are free pages just because some oldest buffer has not freed
2, add log info when SharedMemoryMgr cann't malloc new pages
3, fix bug in testcase